### PR TITLE
fix: make dayjs locale reactive on language switch

### DIFF
--- a/components/base/article-card.vue
+++ b/components/base/article-card.vue
@@ -1,11 +1,13 @@
 <script lang="ts" setup>
 import type { SanityPage } from '~/@types/sanity'
 
+import { computed } from 'vue'
 import dayjs from 'dayjs'
 import relativeTime from 'dayjs/plugin/relativeTime'
 
 const { article } = defineProps<ArticleProps>()
 const { t } = useTranslations()
+const { lang } = useLanguage()
 
 dayjs.extend(relativeTime)
 
@@ -16,7 +18,7 @@ interface ArticleProps {
 const articleReleaseDate
   = article._createdAt === null ? new Date() : new Date(article._createdAt)
 
-const howLong = dayjs(articleReleaseDate).from(Date.now())
+const howLong = computed(() => dayjs(articleReleaseDate).locale(lang.value).from(Date.now()))
 </script>
 
 <template>

--- a/components/base/article-card.vue
+++ b/components/base/article-card.vue
@@ -1,9 +1,9 @@
 <script lang="ts" setup>
 import type { SanityPage } from '~/@types/sanity'
 
-import { computed } from 'vue'
 import dayjs from 'dayjs'
 import relativeTime from 'dayjs/plugin/relativeTime'
+import { computed } from 'vue'
 
 const { article } = defineProps<ArticleProps>()
 const { t } = useTranslations()

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -1,6 +1,5 @@
 <script lang="ts" setup>
 import { useDark, usePreferredReducedMotion } from '@vueuse/core'
-import dayjs from 'dayjs'
 import PageHeader from '~/components/page-header.vue'
 import { useLanguage } from '~/composables/useLanguage'
 import 'dayjs/locale/de'
@@ -8,7 +7,6 @@ import 'dayjs/locale/de'
 const header = ref<{ isMenuOpen: boolean }>({ isMenuOpen: false })
 const { lang } = useLanguage()
 
-dayjs.locale(lang.value)
 
 const prefersReducedMotion = usePreferredReducedMotion()
 useDark({

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -7,7 +7,6 @@ import 'dayjs/locale/de'
 const header = ref<{ isMenuOpen: boolean }>({ isMenuOpen: false })
 const { lang } = useLanguage()
 
-
 const prefersReducedMotion = usePreferredReducedMotion()
 useDark({
   storageKey: 'vuelfden-color-mode',


### PR DESCRIPTION
## Problem

On `/ramblings`, switching language left dayjs relative time strings stale — e.g. switching to German still showed "published 3 days ago" instead of "vor 3 Tagen".

Two causes:
1. `howLong` in `article-card.vue` was a plain string, computed once at setup and never re-evaluated
2. `layouts/default.vue` called `dayjs.locale()` once at setup as a non-reactive side effect

## Fix

**`article-card.vue`**: `howLong` is now a `computed` using `.locale(lang.value)` on the dayjs instance. Vue tracks `lang.value` as a reactive dependency and re-evaluates on language switch.

**`layouts/default.vue`**: The redundant `dayjs.locale()` call is removed entirely. The `'dayjs/locale/de'` side-effect import stays to register the locale. No watchers needed.

## Tests

All 21 unit tests passing.